### PR TITLE
Add include-tables option and progress status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Check `pgdatadiff --help`
 
 Docker images are available.
 
-`docker run -it davidjmarkey/pgdatadiff:0.2.1 /usr/bin/pgdatadiff`
+```
+docker run -it davidjmarkey/pgdatadiff:0.2.1 /usr/bin/pgdatadiff --help
+```
 
 

--- a/pgdatadiff/main.py
+++ b/pgdatadiff/main.py
@@ -1,6 +1,6 @@
 """
 Usage:
-  pgdatadiff --firstdb=<firstconnectionstring> --seconddb=<secondconnectionstring> [--schema=<schema>] [--only-data|--only-sequences] [--count-only] [--count-with-max] [--chunk-size=<size>] [--exclude-tables=<table1,table2>]
+  pgdatadiff --firstdb=<firstconnectionstring> --seconddb=<secondconnectionstring> [--schema=<schema>] [--only-data|--only-sequences] [--count-only] [--count-with-max] [--chunk-size=<size>] [--exclude-tables=<table1,table2>] [--include-tables=<table1,table2>]
   pgdatadiff --version
 
 Options:
@@ -11,7 +11,8 @@ Options:
   --schema="public"         The schema of tables in comparison
   --only-data        Only compare data, exclude sequences
   --only-sequences   Only compare seqences, exclude data
-  --exclude-tables=""   Exclude tables from data comparison         Must be a comma separated string [default: empty string]
+  --exclude-tables=""   Exclude tables from data comparison         Must be a comma separated string
+  --include-tables=""   Only include tables in data comparison      Must be a comma separated string
   --count-only       Do a quick test based on counts alone
   --chunk-size=10000       The chunk size when comparing data [default: 10000]
   --count-with-max    Use MAX(id) when a table uses a sequence, otherwise use COUNT.
@@ -39,6 +40,7 @@ def main():
                     count_only=arguments['--count-only'],
                     count_with_max=arguments['--count-with-max'],
                     exclude_tables=arguments['--exclude-tables'],
+                    include_tables=arguments['--include-tables'],
                     schema=arguments['--schema'])
 
     if not arguments['--only-sequences']:


### PR DESCRIPTION
I added a new `--include-tables` option to the tool, which goes well with your `--exclude-tables` options.
I also added a progression percentage for tables larger than `--chunk-size`.

Hopefully, if you accept these changes, we can push them to the original author.